### PR TITLE
Minor fixes in docs

### DIFF
--- a/content/libraries/index.md
+++ b/content/libraries/index.md
@@ -8,7 +8,7 @@
 
 If you're looking to get the addresses and ABIs of any Synthetix contract, or maybe the list of synths and their parameters, the best way is to use our [`synthetix` `npm` module](synthetix.md#usage-and-requirements) (written for nodejs). Instead of looking it up online, the module contains all the details available to fetch locally (we manage this during our deployment processes).
 
-If you'd rather than functionality in the browser, you'll need to use our [`synthetix-js` JavaScript library on `npm`](synthetix-js.md).
+If you'd rather use this functionality in the browser, you'll need to use our [`synthetix-js` JavaScript library on `npm`](synthetix-js.md).
 
 ### Read and write state
 

--- a/content/releases.md
+++ b/content/releases.md
@@ -2,6 +2,23 @@
 
     Imported from https://github.com/Synthetixio/synthetix/releases
 
+# Antares (v2.25.0)
+
+**Published**: Jul 20, 2020
+
+**Codebase**: [v2.25.0](https://github.com/Synthetixio/synthetix/tree/v2.25.0)
+
+> https://blog.synthetix.io/the-antares-release/
+
+Implements most of [SIP-71](https://sips.synthetix.io/sips/sip-71):
+
+- Allow market creators to cancel a market if no bids have been placed on it yet
+- Allow market creators to disable bid withdrawals at market creation
+- Emit bid events for the initial capital at market creation
+- Fix a bug that prevents creators from exercising their options before expiry under certain circumstances
+
+---
+
 # Aldebaran (2.24.0)
 
 **Published**: Jul 1, 2020


### PR DESCRIPTION
Simply fixing minor typos I found while reading the documentation.

Also, I noticed that the Antares release was added to `content/releases.md` after running ```npm run build```.