### PR TITLE
update ProxysUSD in addresses.md

### DIFF
--- a/content/addresses.md
+++ b/content/addresses.md
@@ -434,7 +434,7 @@ Here is the list of all contracts within the current Synthetix system.
                 <td>ProxysUSD</td>
                 <td><a target="_blank" href="https://github.com/Synthetixio/synthetix/blob/master/contracts/Proxy.sol">Proxy.sol</a></td>
                 <td><a target="_blank" href="https://raw.githubusercontent.com/Synthetixio/synthetix-js/master/lib/abis/mainnet/Proxy.json">Proxy.json</a></td>
-                <td><a target="_blank" href="https://etherscan.io/address/0x57Ab1E02fEE23774580C119740129eAC7081e9D3">0x57Ab1E02fEE23774580C119740129eAC7081e9D3</a>
+                <td><a target="_blank" href="https://etherscan.io/address/0x57Ab1ec28D129707052df4dF418D58a2D46d5f51">0x57Ab1ec28D129707052df4dF418D58a2D46d5f51</a>
                 </td>
               </tr>
               <tr>


### PR DESCRIPTION
[0x57Ab1E02fEE23774580C119740129eAC7081e9D3](https://etherscan.io/address/0x57Ab1E02fEE23774580C119740129eAC7081e9D3) is outdated:

![Annotation 2020-07-26 224430](https://user-images.githubusercontent.com/8782666/88487935-464f5300-cf92-11ea-8a4e-136853eca45a.jpg)

[0x57Ab1ec28D129707052df4dF418D58a2D46d5f51](https://etherscan.io/address/0x57ab1ec28d129707052df4df418d58a2d46d5f51) seems to be the latest version of ProxysUSD.