### PR TITLE
Remove "Not yet on mainnet" warning from AddressResolver docs

### DIFF
--- a/content/contracts/source/contracts/AddressResolver.md
+++ b/content/contracts/source/contracts/AddressResolver.md
@@ -80,10 +80,6 @@ Returns a single address by it's `bytes32` key.
 
 <sub>[Source](https://github.com/Synthetixio/synthetix/tree/v2.46.0-ovm/contracts/AddressResolver.sol#L59)</sub>
 
-!!! Warning "Not yet on mainnet"
-
-    This view, while in source, is not yet on mainnet. It is planned in the `v2.23` Acrux release. As a workaround you can use `IAddressResolver.getAddress("Synthetix").synths(key)`
-
 ??? example "Details"
 
     **Signature**

--- a/content/contracts/source/interfaces/IAddressResolver.md
+++ b/content/contracts/source/interfaces/IAddressResolver.md
@@ -28,10 +28,6 @@
 
 <sub>[Source](https://github.com/Synthetixio/synthetix/tree/v2.46.0-ovm/contracts/interfaces/IAddressResolver.sol#L7)</sub>
 
-!!! Warning "Not yet on mainnet"
-
-    This view, while in source, is not yet on mainnet. It is planned in the `v2.23` Acrux release. As a workaround you can use `IAddressResolver.getAddress("Synthetix").synths(key)`
-
 ??? example "Details"
 
     **Signature**


### PR DESCRIPTION
The docs for AddressResolver say that `getSynth` isn't available on mainnet yet since its still planned for the Acrux release. However, the Acrux release happened last year, and the `getSynth` function works fine on the AddressResolver contract on mainnet. So there is no need for the warning.

The pages I modified:
- https://docs.synthetix.io/contracts/source/contracts/AddressResolver/#getsynth
- https://docs.synthetix.io/contracts/source/interfaces/IAddressResolver/#getsynth